### PR TITLE
Simple change to plugin.py to mark any resource that has a URL as an …

### DIFF
--- a/ckanext/snap_harvester/plugin.py
+++ b/ckanext/snap_harvester/plugin.py
@@ -97,6 +97,8 @@ class SnapHarvester(CSWHarvester, SingletonPlugin):
             elif resource['name'].lower() == 'xml metadata':
                 pprint(resource)
                 resource['format'] = 'XML'
+            elif resource['url']:
+                resource['format'] = 'HTML'
 
         # Rebuild the package extras as a list
         package_dict['extras'] = []


### PR DESCRIPTION
…HTML document, but only if this isn't the XML document from Athena.

Resolves https://github.com/ua-snap/data-distribution/issues/5 
