### PR TITLE
Change ingest schema version number & bugfix

### DIFF
--- a/ckanext/snap_harvester/plugin.py
+++ b/ckanext/snap_harvester/plugin.py
@@ -31,7 +31,7 @@ class SnapHarvester(CSWHarvester, SingletonPlugin):
 
         namespaces = {
             "gts": "http://www.isotc211.org/2005/gts",
-            "gml": "http://www.opengis.net/gml",
+            "gml": "http://www.opengis.net/gml/3.2",
             "gmx": "http://www.isotc211.org/2005/gmx",
             "gsr": "http://www.isotc211.org/2005/gsr",
             "gss": "http://www.isotc211.org/2005/gss",
@@ -43,7 +43,7 @@ class SnapHarvester(CSWHarvester, SingletonPlugin):
         }
 
         package_dict = super(SnapHarvester, self).get_package_dict(iso_values, harvest_object)
-        
+
         tree = etree.fromstring(harvest_object.content)
 
         # Convert package extras to a dictionary to ease manipulation
@@ -70,10 +70,14 @@ class SnapHarvester(CSWHarvester, SingletonPlugin):
         extras['credits'] = json.dumps(credits)
 
         # Spatial resolution: Will get two values, one for x and one for y; we can assume square pixels for the moment.
-        spatial_resolution = tree.xpath('//gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:axisDimensionProperties/gmd:MD_Dimension/gmd:resolution/gco:Angle/text()', namespaces=namespaces)[0]
-        spatial_resolution_units = tree.xpath('//gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:axisDimensionProperties/gmd:MD_Dimension/gmd:resolution/gco:Angle/@uom', namespaces=namespaces)[0]
-        extras['spatial-resolution'] = spatial_resolution
-        extras['spatial-resolution-units'] = spatial_resolution_units
+        spatial_resolution = tree.xpath('//gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:axisDimensionProperties/gmd:MD_Dimension/gmd:resolution/gco:Angle/text()', namespaces=namespaces)
+        if spatial_resolution:
+            # If present, pick the first value.
+            extras['spatial-resolution'] = spatial_resolution[0]
+
+        spatial_resolution_units = tree.xpath('//gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:axisDimensionProperties/gmd:MD_Dimension/gmd:resolution/gco:Angle/@uom', namespaces=namespaces)
+        if spatial_resolution_units:
+            extras['spatial-resolution-units'] = spatial_resolution_units[0]
 
         # Temporal extent: The way we fetch temporal-start and temporal-end can be different from what the built-in xpath uses.
         temporal_extent_begin = tree.xpath('//gml:TimePeriod/gml:beginPosition/text()', namespaces=namespaces)


### PR DESCRIPTION
Some data sets that did not have explicit spatial resolution would fail to ingest.  The harvester now performs a check so no errors occur.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/ckanext-snap_harvester/35)

<!-- Reviewable:end -->
